### PR TITLE
chore(nix): use cargo2nix.overlays.default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
   outputs = { self, nixpkgs, flake-utils, rust-overlay, cargo2nix, ... }@inputs:
     flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
       let
-        overlays = [ cargo2nix.overlay (import rust-overlay) ];
+        overlays = [ cargo2nix.overlays.default (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
         rustPkgs = pkgs.rustBuilder.makePackageSet {
           packageFun = import ./Cargo.nix;


### PR DESCRIPTION
The old cargo2nix.overlay is outdated
